### PR TITLE
Disambiguate `div` usage to make code elm-0.19.1 compatible

### DIFF
--- a/src/Views/App.elm
+++ b/src/Views/App.elm
@@ -4,7 +4,7 @@ import Css exposing (..)
 import Css.Global exposing (..)
 import Data.Msg exposing (Msg)
 import Html exposing (Html)
-import Html.Styled as HS exposing (div, text, toUnstyled)
+import Html.Styled as HS exposing (toUnstyled)
 import Html.Styled.Attributes exposing (css)
 import Views.Theme exposing (theme)
 
@@ -28,7 +28,7 @@ view content =
                 , after [ boxSizing borderBox ]
                 ]
             ]
-        , div
+        , HS.div
             [ css
                 [ Css.property "display" "grid"
                 , Css.property "grid-template-columns" "13fr 21fr"


### PR DESCRIPTION
In the upcoming elm 0.19.1 release, a bug in the elm compiler was fixed (https://github.com/elm/compiler/issues/1945) which makes your code incomatible with the 0.19.1 release.

This PR fixes the problem by disambiguating usage of the `div` import which may come from two packages imported in the affected module: `Css.Global.div` and `Html.Styled.div`.